### PR TITLE
trigger update for kube-HPC.github.io when changes are made in hkubectl

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,3 +84,9 @@ jobs:
           asset_path: /tmp/checksums.txt
           asset_name: checksums.txt
           asset_content_type: text/plain
+      - name: Trigger Update Files in kube-HPC.github.io
+        run: |
+          curl -X POST https://api.github.com/repos/kube-HPC/kube-HPC.github.io/dispatches \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"event_type": "hkubectl-release"}'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,9 +84,3 @@ jobs:
           asset_path: /tmp/checksums.txt
           asset_name: checksums.txt
           asset_content_type: text/plain
-      - name: Trigger Update Files in kube-HPC.github.io
-        run: |
-          curl -X POST https://api.github.com/repos/kube-HPC/kube-HPC.github.io/dispatches \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"event_type": "hkubectl-release"}'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,3 +84,9 @@ jobs:
           asset_path: /tmp/checksums.txt
           asset_name: checksums.txt
           asset_content_type: text/plain
+      - name: Trigger Update Files in kube-HPC.github.io
+        run: |
+          curl -X POST https://api.github.com/repos/kube-HPC/kube-HPC.github.io/dispatches \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+            -d '{"event_type": "hkubectl-release"}'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ name: CI-PR
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events but only for the master branch.
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,3 +34,9 @@ jobs:
         with:
           name: output
           path: ./output/
+      - name: Trigger Update Files in kube-HPC.github.io
+        run: |
+          curl -X POST https://api.github.com/repos/kube-HPC/kube-HPC.github.io/dispatches \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"event_type": "hkubectl-release"}'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,5 +38,5 @@ jobs:
         run: |
           curl -X POST https://api.github.com/repos/kube-HPC/kube-HPC.github.io/dispatches \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
             -d '{"event_type": "hkubectl-release"}'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ name: CI-PR
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch.
+  # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           sha256sum * > checksums.txt
           sha256sum *
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: output
           path: ./output/

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,9 +34,3 @@ jobs:
         with:
           name: output
           path: ./output/
-      - name: Trigger Update Files in kube-HPC.github.io
-        run: |
-          curl -X POST https://api.github.com/repos/kube-HPC/kube-HPC.github.io/dispatches \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
-            -d '{"event_type": "hkubectl-release"}'

--- a/hkubectl.js
+++ b/hkubectl.js
@@ -74,7 +74,7 @@ const main = async () => {
         .recommendCommands()
         .showHelpOnFail()
         .help()
-        .epilog(chalk.bold('for more information visit http://hkube.io'))
+        .epilog(chalk.bold('for more information visit http://hkube.org'))
         .completion();
 
     yargs.middleware((args) => {


### PR DESCRIPTION
Now sends a trigger to repository `kube-HPC.github.io` when a PR is applied into the repository.
The trigger causes a workflow to start in `kube-HPC.github.io` which updates the hkubectl installation files there.
Related issue - https://github.com/kube-HPC/hkube/issues/2019

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkubectl/79)
<!-- Reviewable:end -->
